### PR TITLE
Upload keypress-multi-event

### DIFF
--- a/keypress-multi-event
+++ b/keypress-multi-event
@@ -1,0 +1,4 @@
+(keypress-multi-event
+ :fetcher github
+ [:repo "Boruch-Baum/MELPA_misc_contrib"]
+ [:files ("keypress-multi-event.el")])


### PR DESCRIPTION
This package provides a method to define multiple functions to be performed for the same keypress. You can use this as a convenience feature to toggle among several functions. It was originally written as the back-end for package `home-end’, allowing those two keys to smartly cycle between moving POINT to the beginning/end of a line, the beginning/end of the window, the beginning/end of the buffer, and back to POINT.

`home-end' is being retired from debian (package `emacs-goodies') and I had been approached to maintain it independently (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=759721#13). After four failed attempts to contact the original authors, I re-wrote the package from scratch (just try diffing!), including creating this generalized back-end that can be used for similar purposes. This very small package is a requirement of `home-end'.

My source repository: https://github.com/Boruch-Baum/MELPA_misc_contrib

### Brief summary of what the package does

[Please write a quick summary of the package.]

### Direct link to the package repository

https://github.com/your/awesome_package

### Your association with the package

[Are you the maintainer? A contributor? An enthusiastic user?]

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [ ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
