### PR TITLE
Upload home-end recipe

### DIFF
--- a/recipes/home-end
+++ b/recipes/home-end
@@ -1,0 +1,4 @@
+(home-end
+ :fetcher github
+ [:repo "Boruch-Baum/MELPA_misc_contrib"]
+ [:files ("home-end.el")])


### PR DESCRIPTION
This package makes HOME/END keys smartly cycle to the beginning/end of a line, the beginning/end of the window, the beginning/end of the buffer, and back to POINT. With a prefix argument, behaves as functions `beginning-of-buffer’/`end-of-buffer’.

A first keypress moves POINT to the beginning/end of a line, or if already there, to the beginning/end of the window, or if already there, to the beginning/end of the buffer. Subsequent keypresses cycle through those operations until returning POINT to its start position. Invoking a PREFIX ARGUMENT prior to the keypress moves POINT consistent with PREFIX ARG M-x beginning-of-buffer / end-of-buffer.

Note that this is a total re-write of an identically-named package that had been bundled into debian’s `emacs-goodies-el’. In 2018, that package was marked for ‘retirement’ due to seeming “to need substantial maintainance and have no upstream home”[1]. The original version had been Copyright 1996 Kai Grossjohann and Toby Speight, and Copyright 2002-2011 Toby Speight, both under GPL3.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=759721#13

### Brief summary of what the package does

[Please write a quick summary of the package.]

### Direct link to the package repository

https://github.com/your/awesome_package

### Your association with the package

[Are you the maintainer? A contributor? An enthusiastic user?]

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [ ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
